### PR TITLE
feat: 适配 Docker 支持 ROS Humble

### DIFF
--- a/docs/migration/humble-migration.md
+++ b/docs/migration/humble-migration.md
@@ -1,0 +1,108 @@
+# ROS Humble Migration Design Document
+
+## Overview
+
+This document describes the migration from ROS 2 Jazzy to ROS 2 Humble for the UR5 Gazebo simulation Docker environment.
+
+## Background
+
+**Issue**: #3 - UR5 ROS2 迁移项目，docker 需要支持 ros humble 版本
+
+**Date**: 2026-04-18
+
+**Author**: Autonomous Dev Agent
+
+## Migration Decision
+
+### Why ROS Humble?
+
+ROS 2 Humble Hawksbill is a Long Term Support (LTS) release with the following advantages:
+
+1. **LTS Support**: Supported until May 2027, providing long-term stability
+2. **Ubuntu 22.04 Base**: More stable and widely deployed than Ubuntu 24.04 (Jazzy)
+3. **Mature Ecosystem**: Larger package availability and community support
+4. **Production Ready**: Proven stability in production environments
+
+### Why Migrate from Jazzy?
+
+While ROS 2 Jazzy is newer, Humble's LTS status makes it more suitable for production deployments where stability is prioritized over cutting-edge features.
+
+## Technical Changes
+
+### 1. Dockerfile Changes
+
+| Component | Before (Jazzy) | After (Humble) |
+|-----------|----------------|----------------|
+| Base Image | `ros:jazzy-ros-base` | `ros:humble-ros-base` |
+| Gazebo Packages | `ros-jazzy-gazebo-ros-pkgs` | `ros-humble-gazebo-ros-pkgs` |
+| Control | `ros-jazzy-gz-ros2-control` | `ros-humble-gz-ros2-control` |
+| MoveIt | `ros-jazzy-moveit-*` | `ros-humble-moveit-*` |
+| Setup Path | `/opt/ros/jazzy/setup.bash` | `/opt/ros/humble/setup.bash` |
+
+### 2. docker-compose.yml Changes
+
+| Service | Before | After |
+|---------|--------|-------|
+| Image Tag | `ur5-gazebo-ros2:jazzy` | `ur5-gazebo-ros2:humble` |
+
+### 3. Package Compatibility
+
+All ROS packages used in this project have Humble equivalents:
+
+- ✅ gazebo-ros-pkgs
+- ✅ gz-ros2-control
+- ✅ joint-state-publisher
+- ✅ joint-trajectory-controller
+- ✅ moveit-ros-move-group
+- ✅ moveit-kinematics
+- ✅ moveit-planners-ompl
+- ✅ moveit-ros-visualization
+- ✅ robot-state-publisher
+- ✅ rviz2
+- ✅ xacro
+
+## Testing Strategy
+
+### Build Verification
+
+```bash
+cd ur5_gazebo_ros2
+docker-compose build
+```
+
+### Runtime Verification
+
+```bash
+# Start Gazebo simulation
+docker-compose up gazebo
+
+# Start RViz visualization (separate terminal)
+docker-compose up rviz
+
+# Start MoveIt (separate terminal)
+docker-compose up moveit
+```
+
+### Functional Tests
+
+1. Verify UR5 model loads in Gazebo
+2. Verify joint state publishing
+3. Verify MoveIt motion planning
+4. Verify RViz visualization
+
+## Rollback Plan
+
+If issues are encountered, rollback is simple:
+
+```bash
+git revert <commit-hash>
+# Or checkout previous version
+git checkout main
+```
+
+## References
+
+- [ROS 2 Humble Release Notes](https://docs.ros.org/en/humble/Releases/Release-Humble-Hawksbill.html)
+- [ROS 2 Jazzy Release Notes](https://docs.ros.org/en/jazzy/Releases/Release-Jazzy-Jalisco.html)
+- [Issue #3](https://github.com/jhaiq/ur5-gazebo-ros2-docker/issues/3)
+- [PR #4](https://github.com/jhaiq/ur5-gazebo-ros2-docker/pull/4)

--- a/docs/test-cases/docker-verification.md
+++ b/docs/test-cases/docker-verification.md
@@ -1,0 +1,166 @@
+# UR5 Gazebo ROS2 Test Cases
+
+## Overview
+
+This document describes test cases for verifying the UR5 Gazebo ROS2 Docker environment.
+
+## Test Environment
+
+- **Docker Image**: `ur5-gazebo-ros2:humble`
+- **ROS Version**: ROS 2 Humble Hawksbill
+- **Base OS**: Ubuntu 22.04 (Jammy)
+
+## Test Cases
+
+### TC-001: Docker Image Build
+
+**Objective**: Verify Docker image builds successfully
+
+**Steps**:
+```bash
+cd ur5_gazebo_ros2
+docker-compose build
+```
+
+**Expected Result**:
+- Build completes without errors
+- Image `ur5-gazebo-ros2:humble` is created
+- All ROS packages are installed
+
+**Status**: ⏳ Pending manual verification
+
+---
+
+### TC-002: Gazebo Simulation Startup
+
+**Objective**: Verify Gazebo simulation starts correctly
+
+**Steps**:
+```bash
+docker-compose up gazebo
+```
+
+**Expected Result**:
+- Container `ur5_gazebo` starts successfully
+- Gazebo window opens (if DISPLAY configured)
+- UR5 robot model loads in simulation
+- No error messages in logs
+
+**Verification**:
+```bash
+docker logs ur5_gazebo | grep -i error
+# Should return no results
+```
+
+**Status**: ⏳ Pending manual verification
+
+---
+
+### TC-003: ROS 2 Topic Verification
+
+**Objective**: Verify ROS 2 topics are published correctly
+
+**Steps**:
+```bash
+# In a separate terminal
+docker exec -it ur5_gazebo bash
+source /opt/ros/humble/setup.bash
+ros2 topic list
+```
+
+**Expected Topics**:
+- `/joint_states`
+- `/robot_description`
+- `/clock`
+
+**Verification**:
+```bash
+ros2 topic echo /joint_states --once
+# Should show joint state data
+```
+
+**Status**: ⏳ Pending manual verification
+
+---
+
+### TC-004: MoveIt Integration
+
+**Objective**: Verify MoveIt motion planning works
+
+**Steps**:
+```bash
+docker-compose up moveit
+```
+
+**Expected Result**:
+- MoveIt node starts successfully
+- Motion planning service is available
+- No error messages
+
+**Verification**:
+```bash
+ros2 service list | grep moveit
+# Should show MoveIt services
+```
+
+**Status**: ⏳ Pending manual verification
+
+---
+
+### TC-005: RViz Visualization
+
+**Objective**: Verify RViz visualization works
+
+**Steps**:
+```bash
+docker-compose up rviz
+```
+
+**Expected Result**:
+- RViz starts successfully
+- UR5 robot model displays correctly
+- No error messages
+
+**Status**: ⏳ Pending manual verification
+
+---
+
+### TC-006: ROS 2 Version Check
+
+**Objective**: Verify ROS 2 Humble is installed
+
+**Steps**:
+```bash
+docker exec -it ur5_gazebo bash
+source /opt/ros/humble/setup.bash
+ros2 --version
+```
+
+**Expected Result**:
+```
+ros2 humble
+```
+
+**Status**: ⏳ Pending manual verification
+
+---
+
+## Build Verification Script
+
+A script is available at `scripts/verify-docker-build.sh` to automate basic verification.
+
+## Manual Testing Checklist
+
+- [ ] Docker image builds successfully
+- [ ] Gazebo simulation starts
+- [ ] UR5 model loads in Gazebo
+- [ ] Joint states are published
+- [ ] MoveIt integration works
+- [ ] RViz visualization works
+- [ ] No error messages in logs
+
+## References
+
+- [Design Document](../migration/humble-migration.md)
+- [Issue #3](https://github.com/jhaiq/ur5-gazebo-ros2-docker/issues/3)
+- [PR #4](https://github.com/jhaiq/ur5-gazebo-ros2-docker/pull/4)

--- a/scripts/verify-docker-build.sh
+++ b/scripts/verify-docker-build.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+# verify-docker-build.sh - Verify Docker image builds successfully
+# 
+# This script performs basic verification of the Docker build process
+# without requiring a full runtime test.
+#
+# Usage: ./scripts/verify-docker-build.sh
+#
+# Exit codes:
+#   0 - All checks passed
+#   1 - Build failed or verification error
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+DOCKER_DIR="${PROJECT_DIR}/ur5_gazebo_ros2"
+
+echo "=== UR5 Gazebo ROS2 Docker Build Verification ==="
+echo "Project Directory: ${PROJECT_DIR}"
+echo "Docker Directory: ${DOCKER_DIR}"
+echo ""
+
+# Check 1: Verify Dockerfile exists
+echo "Check 1: Verifying Dockerfile exists..."
+if [[ ! -f "${DOCKER_DIR}/docker/Dockerfile" ]]; then
+    echo "❌ FAIL: Dockerfile not found at ${DOCKER_DIR}/docker/Dockerfile"
+    exit 1
+fi
+echo "✅ PASS: Dockerfile found"
+echo ""
+
+# Check 2: Verify docker-compose.yml exists
+echo "Check 2: Verifying docker-compose.yml exists..."
+if [[ ! -f "${DOCKER_DIR}/docker-compose.yml" ]]; then
+    echo "❌ FAIL: docker-compose.yml not found"
+    exit 1
+fi
+echo "✅ PASS: docker-compose.yml found"
+echo ""
+
+# Check 3: Verify ROS Humble base image
+echo "Check 3: Verifying ROS Humble base image..."
+if grep -q "FROM ros:humble-ros-base" "${DOCKER_DIR}/docker/Dockerfile"; then
+    echo "✅ PASS: Base image is ros:humble-ros-base"
+else
+    echo "❌ FAIL: Base image is not ros:humble-ros-base"
+    grep "FROM ros:" "${DOCKER_DIR}/docker/Dockerfile" || true
+    exit 1
+fi
+echo ""
+
+# Check 4: Verify ROS Humble packages
+echo "Check 4: Verifying ROS Humble packages..."
+HUMBLE_PACKAGES=$(grep -c "ros-humble-" "${DOCKER_DIR}/docker/Dockerfile" || true)
+if [[ "$HUMBLE_PACKAGES" -gt 0 ]]; then
+    echo "✅ PASS: Found ${HUMBLE_PACKAGES} ros-humble-* packages"
+else
+    echo "❌ FAIL: No ros-humble-* packages found"
+    exit 1
+fi
+
+# Check for any jazzy references (should be none)
+JAZZY_REFS=$(grep -c "ros-jazzy\|/opt/ros/jazzy" "${DOCKER_DIR}/docker/Dockerfile" || true)
+if [[ "$JAZZY_REFS" -gt 0 ]]; then
+    echo "⚠️  WARNING: Found ${JAZZY_REFS} references to jazzy (should be humble)"
+    grep "ros-jazzy\|/opt/ros/jazzy" "${DOCKER_DIR}/docker/Dockerfile" || true
+else
+    echo "✅ PASS: No jazzy references found"
+fi
+echo ""
+
+# Check 5: Verify docker-compose.yml image tags
+echo "Check 5: Verifying docker-compose.yml image tags..."
+if grep -q "ur5-gazebo-ros2:humble" "${DOCKER_DIR}/docker-compose.yml"; then
+    echo "✅ PASS: Image tag is ur5-gazebo-ros2:humble"
+else
+    echo "❌ FAIL: Image tag is not ur5-gazebo-ros2:humble"
+    grep "image:" "${DOCKER_DIR}/docker-compose.yml" || true
+    exit 1
+fi
+
+# Check for any jazzy tags (should be none)
+JAZZY_TAGS=$(grep -c ":jazzy" "${DOCKER_DIR}/docker-compose.yml" || true)
+if [[ "$JAZZY_TAGS" -gt 0 ]]; then
+    echo "⚠️  WARNING: Found ${JAZZY_TAGS} jazzy tags in docker-compose.yml"
+    grep ":jazzy" "${DOCKER_DIR}/docker-compose.yml" || true
+else
+    echo "✅ PASS: No jazzy tags found"
+fi
+echo ""
+
+# Check 6: Verify documentation exists
+echo "Check 6: Verifying documentation..."
+if [[ -f "${PROJECT_DIR}/docs/migration/humble-migration.md" ]]; then
+    echo "✅ PASS: Migration design document exists"
+else
+    echo "⚠️  WARNING: Migration design document not found"
+fi
+
+if [[ -f "${PROJECT_DIR}/docs/test-cases/docker-verification.md" ]]; then
+    echo "✅ PASS: Test cases document exists"
+else
+    echo "⚠️  WARNING: Test cases document not found"
+fi
+echo ""
+
+# Check 7: Docker availability (optional)
+echo "Check 7: Checking Docker availability..."
+if command -v docker &>/dev/null; then
+    echo "✅ Docker is available"
+    if docker info &>/dev/null; then
+        echo "✅ Docker daemon is running"
+        echo ""
+        echo "Optional: Run full build test with:"
+        echo "  cd ${DOCKER_DIR} && docker-compose build"
+    else
+        echo "⚠️  Docker daemon is not running (skip build test)"
+    fi
+else
+    echo "⚠️  Docker not installed (skip build test)"
+fi
+echo ""
+
+echo "=== Verification Complete ==="
+echo ""
+echo "Summary:"
+echo "  ✅ All static checks passed"
+echo "  📝 Documentation verified"
+echo "  🔨 Run 'docker-compose build' for full build test"
+echo ""
+
+exit 0

--- a/ur5_gazebo_ros2/docker-compose.yml
+++ b/ur5_gazebo_ros2/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     build:
       context: .
       dockerfile: ur5_gazebo_ros2/docker/Dockerfile
-    image: ur5-gazebo-ros2:jazzy
+    image: ur5-gazebo-ros2:humble
     container_name: ur5_gazebo
     environment:
       - DISPLAY=${DISPLAY}
@@ -25,7 +25,7 @@ services:
 
   # RViz2 Visualization
   rviz:
-    image: ur5-gazebo-ros2:jazzy
+    image: ur5-gazebo-ros2:humble
     container_name: ur5_rviz
     environment:
       - DISPLAY=${DISPLAY}
@@ -42,7 +42,7 @@ services:
 
   # MoveIt2
   moveit:
-    image: ur5-gazebo-ros2:jazzy
+    image: ur5-gazebo-ros2:humble
     container_name: ur5_moveit
     environment:
       - ROS_DOMAIN_ID=${ROS_DOMAIN_ID:-0}

--- a/ur5_gazebo_ros2/docker/Dockerfile
+++ b/ur5_gazebo_ros2/docker/Dockerfile
@@ -1,5 +1,5 @@
 # UR5 Gazebo ROS2 Docker Image
-FROM ros:jazzy-ros-base
+FROM ros:humble-ros-base
 
 # Set environment
 ENV DEBIAN_FRONTEND=noninteractive
@@ -11,17 +11,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-pip \
     python3-colcon-common-extensions \
     python3-rosdep \
-    ros-jazzy-gazebo-ros-pkgs \
-    ros-jazzy-gz-ros2-control \
-    ros-jazzy-joint-state-publisher \
-    ros-jazzy-joint-trajectory-controller \
-    ros-jazzy-moveit-ros-move-group \
-    ros-jazzy-moveit-kinematics \
-    ros-jazzy-moveit-planners-ompl \
-    ros-jazzy-moveit-ros-visualization \
-    ros-jazzy-robot-state-publisher \
-    ros-jazzy-rviz2 \
-    ros-jazzy-xacro \
+    ros-humble-gazebo-ros-pkgs \
+    ros-humble-gz-ros2-control \
+    ros-humble-joint-state-publisher \
+    ros-humble-joint-trajectory-controller \
+    ros-humble-moveit-ros-move-group \
+    ros-humble-moveit-kinematics \
+    ros-humble-moveit-planners-ompl \
+    ros-humble-moveit-ros-visualization \
+    ros-humble-robot-state-publisher \
+    ros-humble-rviz2 \
+    ros-humble-xacro \
     libgl1-mesa-glx \
     libglu1-mesa \
     libxrender1 \
@@ -39,7 +39,7 @@ RUN rosdep init && \
     rosdep install --from-paths src --ignore-src -r -y
 
 # Build workspace
-RUN /bin/bash -c '. /opt/ros/jazzy/setup.bash && \
+RUN /bin/bash -c '. /opt/ros/humble/setup.bash && \
     colcon build --symlink-install && \
     rm -rf build log'
 


### PR DESCRIPTION
## 修改内容

适配 Docker 配置以支持 ROS Humble 版本。

### Dockerfile 更新
- 基础镜像：`ros:jazzy-ros-base` → `ros:humble-ros-base`
- ROS 包名前缀：`ros-jazzy-*` → `ros-humble-*`
- ROS 环境路径：`/opt/ros/jazzy/` → `/opt/ros/humble/`

### docker-compose.yml 更新
- 镜像标签：`ur5-gazebo-ros2:jazzy` → `ur5-gazebo-ros2:humble`

## 测试步骤

```bash
cd ur5_gazebo_ros2
docker-compose build
```

Closes #3